### PR TITLE
removing the 'pin' item from connection_kwargs in serial mode

### DIFF
--- a/samsung_mdc/connection.py
+++ b/samsung_mdc/connection.py
@@ -78,6 +78,9 @@ class MDCConnection:
             # Make this package optional
             from serial_asyncio import open_serial_connection
 
+            # Removing the pin item, otherwise pyserial raises a ValueError
+            self.connection_kwargs.pop('pin', None)
+
             self.reader, self.writer = \
                 await wait_for(
                     open_serial_connection(


### PR DESCRIPTION
In `serial` mode I got a `ValueError` exception, raised by pyserial because of the `pin` item in `connection_kwargs`:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/samsung_mdc/cli.py", line 542, in call
    await mdc_call(connection, display_id)
  File "/usr/local/lib/python3.10/dist-packages/samsung_mdc/cli.py", line 388, in mdc_call
    _repr(await self.mdc_command(connection, display_id,
  File "/usr/local/lib/python3.10/dist-packages/samsung_mdc/command.py", line 51, in __call__
    await connection.send(
  File "/usr/local/lib/python3.10/dist-packages/samsung_mdc/connection.py", line 165, in send
    await self.open()
  File "/usr/local/lib/python3.10/dist-packages/samsung_mdc/connection.py", line 82, in open
    await wait_for(
  File "/usr/local/lib/python3.10/dist-packages/samsung_mdc/connection.py", line 19, in wait_for
    return await asyncio.wait_for(aw, timeout)
  File "/usr/lib/python3.10/asyncio/tasks.py", line 445, in wait_for
    return fut.result()
  File "/usr/local/lib/python3.10/dist-packages/serial_asyncio/__init__.py", line 504, in open_serial_connection
    transport, _ = await create_serial_connection(
  File "/usr/local/lib/python3.10/dist-packages/serial_asyncio/__init__.py", line 448, in create_serial_connection
    serial_instance = serial.serial_for_url(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/serial/__init__.py", line 87, in serial_for_url
    instance = klass(None, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/serial/serialutil.py", line 241, in __init__
    raise ValueError('unexpected keyword arguments: {!r}'.format(kwargs))
ValueError: unexpected keyword arguments: {'pin': None}
```