### PR TITLE
emdx displays content download command

### DIFF
--- a/samsung_mdc/commands.py
+++ b/samsung_mdc/commands.py
@@ -1444,3 +1444,47 @@ class VIDEO_WALL_MODEL(Command):
     GET, SET = True, True
 
     DATA = [VideoWallModel('MODEL'), Int('SERIAL', range(1, 256))]
+
+
+class CONTENT_DOWNLOAD(Command):
+    """
+    Set content download URL for emdx e-paper displays.
+    First two parameters are constants 83 and 128
+
+    Example: content_download(display_id,[83,128,
+        len('http://192.168.2.189:8000/content.json'),
+        'http://192.168.2.189:8000/content.json'])
+
+    Note: This commands passes the URL to a content.json file and not 
+    to an image directly. The json file should contain the required data
+    for the emdx to download and display the image.
+
+    Example Json file:
+
+    {"schedule":
+    [{
+        "start_date":"1970-01-01",
+        "stop_date":"2999-12-31",
+        "start_time":"00:00:00",
+        "contents":
+        [{
+            "image_url":"http://192.168.2.10:8000/image",
+            "file_id":"2B8AECD5-1FE5-4A0A-955E-BF52607A8873",
+            "file_path":"/home/owner/content/Downloads/vxtplayer/epaper/mobile/contents/2B8AECD5-1FE5-4A0A-955E-BF52607A8873/2B8AECD5-1FE5-4A0A-955E-BF52607A8873.png",
+            "duration":91326,"file_size":"5125303",
+            "file_name":"2B8AECD5-1FE5-4A0A-955E-BF52607A8873.png"
+        }]
+    }],
+    "name":"node-samsung-emdx",
+    "version":1,
+    "create_time":"2025-01-01 00:00:00",
+    "id":"2B8AECD5-1FE5-4A0A-955E-BF52607A8873",
+    "program_id":"com.samsung.ios.ePaper",
+    "content_type":"ImageContent",
+    "deploy_type":"MOBILE"}
+
+    """
+    CMD = 0xC7
+    GET, SET = False, True
+
+    DATA = [Int('83'),Int('128'),Int('URL_length', range(1, 255)),Str('URL')]

--- a/samsung_mdc/commands.py
+++ b/samsung_mdc/commands.py
@@ -1443,7 +1443,7 @@ class VIDEO_WALL_MODEL(Command):
     CMD = 0x89
     GET, SET = True, True
 
-    DATA = [VideoWallModel('MODEL'), Int('SERIAL', range(1, 256))]
+    DATA = [VideoWallModel('MODEL'), Int('SERIAL', range(1, 255))]
 
 
 class CONTENT_DOWNLOAD(Command):

--- a/samsung_mdc/commands.py
+++ b/samsung_mdc/commands.py
@@ -1443,7 +1443,7 @@ class VIDEO_WALL_MODEL(Command):
     CMD = 0x89
     GET, SET = True, True
 
-    DATA = [VideoWallModel('MODEL'), Int('SERIAL', range(1, 255))]
+    DATA = [VideoWallModel('MODEL'), Int('SERIAL', range(1, 256))]
 
 
 class CONTENT_DOWNLOAD(Command):


### PR DESCRIPTION
Added command to update the image displayed on emdx displays. I could not really see a clean way without adding a new data type for a fixed header in the command so I just exposed them as parameters when calling the command. Feel free to implement this cleaner if wanted.

example calling the command

```
url = "http://192.168.2.189:8000/content.json"
mdc.content_download(display_id,[83,128,len(url),url])
```


the full byte array is as follows:
| 1 | 2 | 3      | 4                  | 5       | 6      | 7                | 8 to N-1  | N             | 
| ------ | ----- | ----- | ------------- | ----- | ----- | ----------- | -- | ---------- |
| 0xAA | 0xC7 | 0x00 | data.length | 0x53 | 0x80 | url.length | url |checksum|
| mdc Header | Command | display_id | data.length | Constant(83) | Constant(128) | Length of the URL| URL with port number to content.json | standard mdc checksum|

The way this command works is it passes a url to a JSON file to the emdx display. It then downloads the json file and using the url in the json file it downloads and updates the display. Url length must be less than 256.

Example Json file. The UUID must change for each update or the display will not refresh. 

```
{
    "schedule": [
        {
            "start_date": "1970-01-01",
            "stop_date": "2999-12-31",
            "start_time": "00:00:00",
            "contents": [
                {
                    "image_url": "http:\/\/192.168.2.189:8000\/image",
                    "file_id": "865AF97C-580C-4C6B-96A0-AB3B87411EEC",
                    "file_path": "\/home\/owner\/content\/Downloads\/vxtplayer\/epaper\/mobile\/contents\/865AF97C-580C-4C6B-96A0-AB3B87411EEC\/865AF97C-580C-4C6B-96A0-AB3B87411EEC.png",
                    "duration": 91326,
                    "file_size": "1222255",
                    "file_name": "865AF97C-580C-4C6B-96A0-AB3B87411EEC.png"
                }
            ]
        }
    ],
    "name": "node-samsung-emdx",
    "version": 1,
    "create_time": "2025-01-01 00:00:00",
    "id": "865AF97C-580C-4C6B-96A0-AB3B87411EEC",
    "program_id": "com.samsung.ios.ePaper",
    "content_type": "ImageContent",
    "deploy_type": "MOBILE"
}
```