### PR TITLE
Fix asyncio event loop creation for Python 3.14

### DIFF
--- a/samsung_mdc/cli.py
+++ b/samsung_mdc/cli.py
@@ -524,7 +524,8 @@ def asyncio_run(call, targets, verbose=False):
         loop = asyncio.get_running_loop()
         is_running_loop = True
     except RuntimeError:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
         is_running_loop = False
 
     loop.run_until_complete(asyncio.wait([


### PR DESCRIPTION
Hi!

samsung-mdc fails on python 3.14 because `asyncio.get_event_loop()` no longer creates an event loop automatically when none exists, causing:
`RuntimeError: There is no current event loop in thread 'MainThread'.`

This PR explicitly creates and registers a new event loop when running outside an existing async context.

This keeps the existing behavior on older python versions and restores compatibility with python 3.14.

Tested with python 3.14 and a working samsung mdc connection.