### PR TITLE
add large data and response support

### DIFF
--- a/samsung_mdc/command.py
+++ b/samsung_mdc/command.py
@@ -52,13 +52,17 @@ class Command(metaclass=CommandMcs):
     DATA: List[Union[Type[Enum], Field]]
     RESPONSE_DATA: List[Union[Type[Enum], Field]]
     RESPONSE_EXTRA: List[Union[Type[Enum], Field]]
+    DATA_LENGTH_LARGE: bool = False
+    RESPONSE_LENGTH_LARGE: bool = False
 
     async def __call__(self, connection, display_id, data):
         data = self.parse_response(
             await connection.send(
                 (self.CMD, self.SUBCMD)
                 if self.SUBCMD is not None else self.CMD, display_id,
-                self.pack_payload_data(data) if data else []
+                self.pack_payload_data(data) if data else [],
+                data_length_large=self.DATA_LENGTH_LARGE,
+                response_length_large=self.RESPONSE_LENGTH_LARGE
             ),
         )
         return tuple(self.parse_response_data(data))

--- a/samsung_mdc/connection.py
+++ b/samsung_mdc/connection.py
@@ -37,17 +37,25 @@ def _normalize_cmd(
 def pack_payload(
     cmd: Union[int, Tuple[int], Tuple[int, Union[int, None]]],
     display_id: int,
-    data: Union[bytes, Sequence] = b''
+    data: Union[bytes, Sequence] = b'',
+    data_length_large: bool = False
 ):
     cmd, subcmd = _normalize_cmd(cmd)
     data = bytes(data)
     if subcmd is not None:
         data = bytes([subcmd]) + data
 
-    payload = (
-        bytes([HEADER_CODE, cmd, display_id, len(data)])
-        + bytes(data)
-    )
+    if data_length_large:
+        payload = (
+            bytes([HEADER_CODE, cmd, display_id])
+            + len(data).to_bytes(2, 'big')
+            + bytes(data)
+        )
+    else:
+        payload = (
+            bytes([HEADER_CODE, cmd, display_id, len(data)])
+            + bytes(data)
+        )
     payload += bytes([get_checksum(payload[1:])])
     return payload
 
@@ -218,10 +226,14 @@ class MDCConnection:
         self,
         cmd: Union[int, Tuple[int], Tuple[int, int]],
         display_id: int,
-        data: Union[bytes, Sequence] = b''
+        data: Union[bytes, Sequence] = b'',
+        data_length_large: bool = False,
+        response_length_large: bool = False
     ):
         cmd, subcmd = _normalize_cmd(cmd)
-        payload = pack_payload((cmd, subcmd), display_id, data)
+        payload = pack_payload(
+            (cmd, subcmd), display_id, data,
+            data_length_large=data_length_large)
 
         if not self.is_opened:
             await self.open()
@@ -232,8 +244,9 @@ class MDCConnection:
         if self.verbose:
             self.verbose('Sent', repr_hex(payload))
 
-        resp = await wait_for_read(self.reader, 4, self.timeout,
-                                   'Response header read timeout')
+        resp = await wait_for_read(
+            self.reader, 5 if response_length_large else 4, self.timeout,
+            'Response header read timeout')
         if not resp:
             raise MDCResponseError('Empty response', resp)
         if resp[0] != HEADER_CODE:
@@ -248,7 +261,12 @@ class MDCConnection:
             raise MDCResponseError('Unexpected display_id',
                                    resp + self.reader._buffer)
 
-        length = resp[3]
+        if response_length_large:
+            length = int.from_bytes(resp[3:5], 'big')
+            data_offset = 5
+        else:
+            length = resp[3]
+            data_offset = 4
         resp += await wait_for_read(self.reader, length + 1, self.timeout,
                                     'Response data read timeout')
         if self.verbose:
@@ -258,7 +276,9 @@ class MDCConnection:
         if checksum != int(resp[-1]):
             raise MDCResponseError('Checksum failed', resp)
 
-        ack, rcmd, data = resp[4], resp[5], resp[6:-1]
+        ack = resp[data_offset]
+        rcmd = resp[data_offset + 1]
+        data = resp[data_offset + 2:-1]
         if ack not in (ACK_CODE, NAK_CODE):
             raise MDCResponseError('Unexpected ACK/NAK', resp)
 


### PR DESCRIPTION
i'm working with a Samsung EM32DX-A ePaper display

this adds support for "large frame" data and responses that this panel uses for several commands.  samsung only seems to have commands that specify true, true for data large and response large but there's no reason it can't be async from what i can see

there's very little i can find on the actual difference between the original and `-A`, short of the user guide explicitly stating support for wake on lan.  experimentally there's some interesting changes vs EM32DX.  `-A` has two wifi soc's: one "main" and one "low power" - the latter is a [DA16200](https://www.renesas.com/en/products/da16200) at least in mine.  when (non-deep) sleep mode is activated, it activates the low power wifi module, and deactivates the main.  there's a somewhat bonkers sequence to wake the thing involving repeated udp bursts that the official epaper app does.  usually within ~22s the main soc comes online and it's ready for mdc, at which point the low-power adapter goes offline/non-responsive.  so it kind of functions as a poor man's wake-on-wlan?

there's at least 8 new commands that use this new framing, including finding the low-power adapter mac + ip .  i'll put up a separate pr with those commands